### PR TITLE
Enabled unicode support 

### DIFF
--- a/global.vim
+++ b/global.vim
@@ -7,6 +7,12 @@ filetype plugin indent on
 set noeol
 set binary
 
+" utf-8/unicode support
+" requires Vim to be compiled with Multibyte support, you can check that by
+" running `vim --version` and checking for +multi_byte.
+scriptencoding utf-8
+set encoding=utf-8
+
 " presentation settings
 set number              " precede each line with its line number
 set numberwidth=3       " number of culumns for line numbers


### PR DESCRIPTION
Otherwise Unicode characters were not displayed correctly and setting `listchars` setting with Unicode characters was failing with the message:

```
Error detected while processing /Users/arikfr/dotfiles/dotvim/global.vim:
line   22:
E474: Invalid argument: listchars=tab:?~V??~K~E,trail:·
```
