### PR TITLE
Update information about slim-rails

### DIFF
--- a/bundles.vim
+++ b/bundles.vim
@@ -58,7 +58,7 @@ Bundle 'vitaly/vim-syntastic-coffee'
 Bundle 'vim-scripts/jade.vim'
 Bundle 'wavded/vim-stylus'
 Bundle 'VimClojure'
-Bundle 'bbommarito/vim-slim'
+Bundle 'slim-template/vim-slim'
 
 " Support and minor
 Bundle 'kana/vim-textobj-user'


### PR DESCRIPTION
As stated in #21, slim-rails is now hosted here: git://github.com/slim-template/vim-slim.git

The PR updates bundles.vim. So, any new installation will succeed.
