### PR TITLE
added string interpolation completion and easy surround 

### DIFF
--- a/ftplugin/ruby.vim
+++ b/ftplugin/ruby.vim
@@ -2,3 +2,17 @@ set sw=2
 set ts=2
 set et
 set iskeyword+=!,?,=
+function! s:InsertInterpolation()
+  let before = getline('.')[col('^'):col('.')]
+  let after  = getline('.')[col('.'):col('$')]
+  " check that we're in double-quotes string
+  if before =~# '"' && after =~# '"'
+    execute "normal! a{}\<Esc>h"
+  endif
+endfunction
+inoremap <silent><buffer> # #<Esc>:call <SID>InsertInterpolation()<Cr>a
+
+" Surround with #
+if exists("g:loaded_surround")
+  let b:surround_{char2nr('#')} = "#{\r}"
+endif


### PR DESCRIPTION
Taken from here: https://raw.githubusercontent.com/p0deje/vim-ruby-interpolation/master/ftplugin/ruby.vim

Two features:
1. When inside a string, inserting # automatically puts {} and the cursor inside of them
2. Using vim surround, surround with # inside a string results in #{original_text}

Very useful