### PR TITLE
Add optional ~/.vimrc.bundles file

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -171,6 +171,11 @@ files. There are several override files supported by dotvim.
 They are loaded in the following order:
 
 * base dotvim configuration (global, plugin configurations, bindings, macros)
+* `~/.vimrc.bundles`
+
+  Loads additional bundles inside the `neobundle#begin/end` block.
+  Should contain lines like `NeoBundle 'my-custom/bundle'`
+
 * `~/.local-before.vim` _[deprecated]_
 * `~/.vimrc.before`
 

--- a/bundles.vim
+++ b/bundles.vim
@@ -157,6 +157,10 @@ NeoBundle 'Shougo/unite.vim'
 NeoBundle 'Shougo/unite-outline'
 NeoBundle 'ujihisa/unite-colorscheme'
 
+if filereadable(expand("~/.vimrc.bundles"))
+  source ~/.vimrc.bundles
+endif
+
 call neobundle#end()
 
 filetype plugin indent on


### PR DESCRIPTION
NeoBundle must be inside the neobundle#begin -neobundle#end block
This optional file allows adding custom bundles

This is what I have in it for example:
```
NeoBundle 'ezkl/vim-syntax-vcl'
NeoBundle 'markcornick/vim-terraform'
```

If you like the direction I can also work on adding a few words to the README. Just let me know

Thanks!