### PR TITLE
update readme to not use the git url handler

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -92,7 +92,7 @@ announcements of new versions, tips, etc.
 
 From your homedirectory (on Linux/Mac OSX):
 
-* `git clone git://github.com/astrails/dotvim.git`
+* `git clone https://github.com/astrails/dotvim.git # or git@github.com:astrails/dotvim.git for ssh`
 * `ln -sfn dotvim .vim`
 * `ln -sfn dotvim/vimrc .vimrc`
 * `cd .vim; make install`


### PR DESCRIPTION
the git url (git://) is not secure and the port is often blocked in large enterprises (I'm not even sure github supports it anymore).  The https and ssh urls are safer and not usually blocked (ssh is sometimes).  The https url has the advantage/disadvantage of honoring any https proxies.