### PR TITLE
Fix Vim Airline Themes

### DIFF
--- a/bundles.vim
+++ b/bundles.vim
@@ -42,6 +42,7 @@ NeoBundle 'austintaylor/vim-indentobject'
 NeoBundle 'greplace.vim'
 " better looking statusline
 NeoBundle 'bling/vim-airline'
+NeoBundle 'vim-airline/vim-airline-themes'
 " plugin for resolving three-way merge conflicts
 NeoBundle 'sjl/splice.vim'
 " plugin for visually displaying indent levels


### PR DESCRIPTION
Vim Airline moved its themes, including the `light theme` used in the basic configuration of dotvim to another repository.
By requiring the new repo (which is NeoBundle and Plugin compatible) people can use the basic themes for vim airline again.
